### PR TITLE
Add didDownloadFile event

### DIFF
--- a/SmartSuggestionsSample.xcodeproj/project.pbxproj
+++ b/SmartSuggestionsSample.xcodeproj/project.pbxproj
@@ -23,7 +23,9 @@
 		681BB20225D58A4500FF338C /* STPApplicationPromotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681BB20125D58A4500FF338C /* STPApplicationPromotion.swift */; };
 		681BB20525D58FD500FF338C /* STPPromotionPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681BB20425D58FD500FF338C /* STPPromotionPresenter.swift */; };
 		681BB20825D5903000FF338C /* STPEventController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681BB20725D5903000FF338C /* STPEventController.swift */; };
+		682709EB261722BC002AD4BF /* STPDownloadedFilesEventProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682709EA261722BC002AD4BF /* STPDownloadedFilesEventProcessor.swift */; };
 		68350140261718E800318069 /* STPEventControllersBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6835013F261718E800318069 /* STPEventControllersBuilder.swift */; };
+		6835014C26171B1400318069 /* STPDownloadedFilesEventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6835014B26171B1400318069 /* STPDownloadedFilesEventProducer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,7 +47,9 @@
 		681BB20125D58A4500FF338C /* STPApplicationPromotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPApplicationPromotion.swift; sourceTree = "<group>"; };
 		681BB20425D58FD500FF338C /* STPPromotionPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPromotionPresenter.swift; sourceTree = "<group>"; };
 		681BB20725D5903000FF338C /* STPEventController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPEventController.swift; sourceTree = "<group>"; };
+		682709EA261722BC002AD4BF /* STPDownloadedFilesEventProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPDownloadedFilesEventProcessor.swift; sourceTree = "<group>"; };
 		6835013F261718E800318069 /* STPEventControllersBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPEventControllersBuilder.swift; sourceTree = "<group>"; };
+		6835014B26171B1400318069 /* STPDownloadedFilesEventProducer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPDownloadedFilesEventProducer.swift; sourceTree = "<group>"; };
 		68C988EA25D6B3DC0044E82D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -97,6 +101,7 @@
 			isa = PBXGroup;
 			children = (
 				681BB1EF25D588FB00FF338C /* STPPromotionEvent.swift */,
+				6835014426171A2100318069 /* DownloadedFiles */,
 				683501432617199F00318069 /* LaunchedApps */,
 			);
 			path = "Promotions Sample";
@@ -164,6 +169,15 @@
 				681BB19B25D529DE00FF338C /* STPLaunchedAppsEventProducer.swift */,
 			);
 			path = LaunchedApps;
+			sourceTree = "<group>";
+		};
+		6835014426171A2100318069 /* DownloadedFiles */ = {
+			isa = PBXGroup;
+			children = (
+				6835014B26171B1400318069 /* STPDownloadedFilesEventProducer.swift */,
+				682709EA261722BC002AD4BF /* STPDownloadedFilesEventProcessor.swift */,
+			);
+			path = DownloadedFiles;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -237,9 +251,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				681BB20825D5903000FF338C /* STPEventController.swift in Sources */,
+				6835014C26171B1400318069 /* STPDownloadedFilesEventProducer.swift in Sources */,
 				681BB1B625D5315000FF338C /* STPLaunchedAppsEventProcessor.swift in Sources */,
 				681BB1E825D5884B00FF338C /* UNAuthorizationOptions.swift in Sources */,
 				681BB1F025D588FB00FF338C /* STPPromotionEvent.swift in Sources */,
+				682709EB261722BC002AD4BF /* STPDownloadedFilesEventProcessor.swift in Sources */,
 				681BB1E325D587C300FF338C /* STPDispatchQueueFactory.swift in Sources */,
 				681BB1F425D5891000FF338C /* STPEventProducer.swift in Sources */,
 				681BB20525D58FD500FF338C /* STPPromotionPresenter.swift in Sources */,

--- a/SmartSuggestionsSample/Promotions Sample/DownloadedFiles/STPDownloadedFilesEventProcessor.swift
+++ b/SmartSuggestionsSample/Promotions Sample/DownloadedFiles/STPDownloadedFilesEventProcessor.swift
@@ -1,0 +1,53 @@
+//
+//  STPDownloadedFilesEventProcessor.swift
+//  SmartSuggestionsSample
+//
+//  Created by Vitalii Budnik on 4/2/21.
+//  Copyright © 2021 Setapp Ltd. All rights reserved.
+//
+
+import Foundation
+
+class STPDownloadedFilesEventProcessor: STPEventProcessor {
+  func startEventProcessing() {
+    queue.async(execute: _startEventProcessing)
+  }
+
+  func process(event: STPPromotionEvent, callback: @escaping (Bool) -> Void) {
+    queue.async {
+      self._process(event: event, callback: callback)
+    }
+  }
+
+  func stopEventProcessing() {
+    queue.async(execute: _stopEventProcessing)
+  }
+
+  private var canProcessEvents: Bool = false
+  private let queue: DispatchQueue
+  private let filter: (URL) -> Bool
+
+  init(
+    filter: @escaping (URL) -> Bool,
+    queue: DispatchQueue = STPDispatchQueueFactory.shared.queue(label: "downloadedFilesProcessor")
+  )
+  {
+    self.queue = queue
+    self.filter = filter
+  }
+
+  private func _startEventProcessing() {
+    canProcessEvents = true
+  }
+
+  private func _process(event: STPPromotionEvent, callback: @escaping (Bool) -> Void) {
+    guard canProcessEvents else { return }
+    guard case let STPPromotionEvent.didDownloadFile(path: path) = event else { return }
+
+    callback(filter(path))
+  }
+
+  private func _stopEventProcessing() {
+    canProcessEvents = false
+  }
+}

--- a/SmartSuggestionsSample/Promotions Sample/DownloadedFiles/STPDownloadedFilesEventProducer.swift
+++ b/SmartSuggestionsSample/Promotions Sample/DownloadedFiles/STPDownloadedFilesEventProducer.swift
@@ -1,0 +1,136 @@
+//
+//  STPDownloadedFilesEventProducer.swift
+//  SmartSuggestionsSample
+//
+//  Created by Vitalii Budnik on 4/2/21.
+//  Copyright © 2021 Setapp Ltd. All rights reserved.
+//
+
+import Foundation
+
+class STPDownloadedFilesEventProducer: STPEventProducer {
+  var delegate: STPEventProducerDelegate?
+
+  func startEventProducing() {
+    queue.async(execute: _startEventProducing)
+  }
+
+  func stopEventProducing() {
+    queue.async(execute: _stopEventProducing)
+  }
+
+  /// Working queue.
+  private let queue: DispatchQueue
+  /// FS monitoring queue.
+  private let monitoringQueue: DispatchQueue
+
+  /// A reference to the current file system events stream.
+  private var currentStreamRef: FSEventStreamRef?
+
+  init(
+    queue: DispatchQueue = STPDispatchQueueFactory.shared.queue(label: "downloadedFilesMonitor"),
+    monitoringQueue: DispatchQueue = STPDispatchQueueFactory.shared.queue(label: "downloadedFilesMonitor.monitoringQueue")
+  )
+  {
+    self.queue = queue
+    self.monitoringQueue = monitoringQueue
+  }
+
+  private func _startEventProducing() {
+    guard currentStreamRef == .none else { return }
+
+    var context = FSEventStreamContext(
+      version: 0,
+      info: nil,
+      retain: nil,
+      release: nil,
+      copyDescription: nil
+    )
+    context.info = Unmanaged.passUnretained(self).toOpaque()
+
+    let flags = UInt32(
+      kFSEventStreamCreateFlagUseCFTypes |
+        kFSEventStreamCreateFlagFileEvents |
+        kFSEventStreamCreateFlagNoDefer |
+        kFSEventStreamCreateFlagMarkSelf
+    )
+
+    let downloadsFolderPath = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask)[0].path
+
+    guard let streamRef = FSEventStreamCreate(
+      kCFAllocatorDefault,
+      Self.eventCallback,
+      &context,
+      [downloadsFolderPath] as CFArray,
+      FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+      0.3,
+      flags
+    )
+    else {
+      return
+    }
+
+    FSEventStreamSetDispatchQueue(streamRef, self.monitoringQueue);
+    FSEventStreamStart(streamRef)
+
+    self.currentStreamRef = streamRef
+  }
+
+  private func _stopEventProducing() {
+    guard let stream = currentStreamRef else { return }
+    defer { currentStreamRef = nil }
+
+    FSEventStreamStop(stream)
+    FSEventStreamInvalidate(stream)
+    FSEventStreamRelease(stream)
+  }
+
+  private static let eventCallback: FSEventStreamCallback = {
+    (streamRef: ConstFSEventStreamRef,
+     clientCallBackInfo: UnsafeMutableRawPointer?,
+     numEvents: Int,
+     eventPaths: UnsafeMutableRawPointer,
+     eventFlags: UnsafePointer<FSEventStreamEventFlags>,
+     eventIds: UnsafePointer<FSEventStreamEventId>) in
+
+    let monitor: STPDownloadedFilesEventProducer = unsafeBitCast(
+      clientCallBackInfo,
+      to: STPDownloadedFilesEventProducer.self
+    )
+
+    guard monitor.currentStreamRef == streamRef else { return }
+
+    monitor.handle(numEvents: numEvents,
+                   eventPaths: eventPaths,
+                   streamEventFlags: eventFlags,
+                   eventIds: eventIds)
+  }
+
+  private func handle(
+    numEvents: Int,
+    eventPaths: UnsafeMutableRawPointer,
+    streamEventFlags: UnsafePointer<FSEventStreamEventFlags>,
+    eventIds: UnsafePointer<FSEventStreamEventId>
+  )
+  {
+    guard let paths = unsafeBitCast(eventPaths, to: NSArray.self) as? [String] else { return }
+
+    for index in 0..<numEvents {
+      let currentFlags = streamEventFlags[index]
+
+      // If this is file, and it was created.
+      guard
+        (Int(currentFlags) & kFSEventStreamEventFlagItemIsFile > 0) &&
+          (Int(currentFlags) & kFSEventStreamEventFlagItemCreated > 0)
+      else {
+        return
+      }
+      let path = URL(fileURLWithPath: paths[index])
+
+      queue.async {
+        // Tell the delegate about new event.
+        self.delegate?.didProduceEvent(.didDownloadFile(path: path))
+      }
+    }
+  }
+}

--- a/SmartSuggestionsSample/Promotions Sample/STPPromotionEvent.swift
+++ b/SmartSuggestionsSample/Promotions Sample/STPPromotionEvent.swift
@@ -16,4 +16,6 @@ import Foundation
 enum STPPromotionEvent: Hashable {
   /// An application did launch.
   case didLaunchApp(bundleID: String)
+  /// A new file appeared in Downloads folder.
+  case didDownloadFile(path: URL)
 }

--- a/SmartSuggestionsSample/STPEventControllersBuilder.swift
+++ b/SmartSuggestionsSample/STPEventControllersBuilder.swift
@@ -37,4 +37,26 @@ class STPEventControllersBuilder {
 
     return launchEventsController
   }
+
+  func downloadedFilesEventsController() -> STPEventController {
+    let producer = STPDownloadedFilesEventProducer()
+    let processor = STPDownloadedFilesEventProcessor(
+      filter: { url in url.pathExtension.lowercased() == "rar" }
+    )
+
+    let controller = STPEventController(
+      producer: producer,
+      processor: processor,
+      presenter: STPDefaultPromotionPresenter()
+    ) { event in
+      // Q: Will promotion texts be used for my app promotion?
+      // A: If we like it - it will be used.
+
+      STPApplicationPromotion(title: "Can't unrar?",
+                              subtitle: "Try AwesomeRar. It's in Setapp!",
+                              body: "Unpack all kinds of archive with a click!")
+    }
+
+    return controller
+  }
 }

--- a/SmartSuggestionsSample/ViewController.swift
+++ b/SmartSuggestionsSample/ViewController.swift
@@ -26,6 +26,7 @@ class ViewController: NSViewController {
 
     eventsControllers = [
       eventControllersBuilder.launchEventsController(),
+      eventControllersBuilder.downloadedFilesEventsController(),
     ]
 
     setupStartStopAvailability()


### PR DESCRIPTION
This PR introduces a new event module: Downloaded Files: tt monitors downloaded files folder and produces events with new file URLs.

The processor is able to filter produced events by file URL.

Also, there is a sample events controller presenting an alert when a new `.rar` file appears in the downloads folder.